### PR TITLE
Minor fixes for dcm classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcm_classifier"
-version = '0.6.0.rc10'
+version = '0.6.0.rc11'
 authors = [
   { name="Michal Brzus", email="michal-brzus@uiowa.edu" },
   { name="Hans Johnson", email="hans-johnson@uiowa.edu" },
 ]
 description = "This is a consolidation of work from NAMIC efforts primarily at the University of Iowa."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/src/dcm_classifier/__init__.py
+++ b/src/dcm_classifier/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("dcm_classifier")

--- a/src/dcm_classifier/dicom_series.py
+++ b/src/dcm_classifier/dicom_series.py
@@ -261,7 +261,7 @@ class DicomSingleSeries:
         # AcquisitionTime is an optional field, this might need to be changed in the future
         sorted(
             self.volume_info_list,
-            key=lambda x: x.get_volume_dictionary()["AcquisitionTime"],
+            key=lambda x: x.get_volume_dictionary().get("AcquisitionTime", -12345),
         )
         # assign the index to each volume
         for index, volume in enumerate(self.volume_info_list):


### PR DESCRIPTION
This pull request introduces minor fixes:
- raises minimum python version dependency from 3.7 (that reached end of life last year) to python 3.9.
- improve robustness of volume sorting within a series
- adds functionality of accessing package version

