### PR TITLE
Fix Pydicom Field Naming in Sanitization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcm_classifier"
-version = '0.6.0.rc11'
+version = '0.6.0.rc12'
 authors = [
   { name="Michal Brzus", email="michal-brzus@uiowa.edu" },
   { name="Hans Johnson", email="hans-johnson@uiowa.edu" },

--- a/src/dcm_classifier/dicom_config.py
+++ b/src/dcm_classifier/dicom_config.py
@@ -51,7 +51,7 @@ optional_DICOM_fields: list[str] = [
     "SAR",  # Not present in all derived image types
     "ImageType",  # Not required
     "Manufacturer",  # Not required
-    "Contrast/BolusAgent",  # "(0x0018, 0x0010)"
+    "ContrastBolusAgent",  # "(0x0018, 0x0010)"
     "Diffusionb-value",  # Not required
     "Diffusionb-valueMax",  # Not required
     "EchoNumbers",
@@ -59,12 +59,12 @@ optional_DICOM_fields: list[str] = [
     "ScanningSequence",
     "SequenceVariant",
     "InPlanePhaseEncodingDirection",
-    "dB/dt",
+    "dBdt",
     "ImagingFrequency",
     "MRAcquisitionType",
     "NumberOfAverages",
     "InversionTime",
-    "Variable Flip Angle Flag",
+    "VariableFlipAngleFlag",
     "AcquisitionTime",
 ]
 
@@ -93,7 +93,7 @@ inference_features: list[str] = [
     "ScanningSequence_SE",
     "SequenceVariant_MP",
     "SequenceVariant_SP",
-    "dB/dt",
+    "dBdt",
     "has_b0",
     "has_pos_b0",
     "likely_diffusion",

--- a/src/dcm_classifier/image_type_inference.py
+++ b/src/dcm_classifier/image_type_inference.py
@@ -210,7 +210,7 @@ class ImageTypeClassifierBase:
             return True
         return False
 
-    def infer_contrast(self, feature_dict: dict = None) -> bool | None:
+    def infer_contrast(self, feature_dict: dict = None) -> bool:
         """
         Infer whether the image has contrast based on DICOM information and image properties.
         Args:
@@ -221,9 +221,9 @@ class ImageTypeClassifierBase:
         """
         # check if the volume was invalidated
 
-        field = "Contrast/BolusAgent"
+        field = "ContrastBolusAgent"
         if field not in feature_dict.keys():
-            return None
+            return False
 
         # check if the volume has contrast
         if "none" not in feature_dict[field].lower():


### PR DESCRIPTION
The purpose of this pull request is to fix the naming convention in the sanitization of datasets. The previous method would not include certain fields after sanitizing as a result of our naming convention not matching pydicoms.