### PR TITLE
28 importlib metadata bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcm_classifier"
-version = '0.6.0.rc12'
+version = '0.7.0.rc1'
 authors = [
   { name="Michal Brzus", email="michal-brzus@uiowa.edu" },
   { name="Hans Johnson", email="hans-johnson@uiowa.edu" },

--- a/src/dcm_classifier/__init__.py
+++ b/src/dcm_classifier/__init__.py
@@ -1,3 +1,8 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version("dcm_classifier")
+try:
+    # Attempt to retrieve the version of the installed package
+    __version__ = importlib.metadata.version("dcm_classifier")
+except importlib.metadata.PackageNotFoundError:
+    # Fallback version if the package is not installed (e.g., in development)
+    __version__ = "0.0.0-dev"


### PR DESCRIPTION
# Overview
This pull request addresses an `ImportError` encountered during local development when the package is not installed. By implementing a try-except block around the `importlib.metadata.version` call, we ensure a smoother development experience, allowing the local codebase to be tested without requiring the package to be installed as a distribution.

# Implementation
Implemented a try-except block in the `__init__.py` file of the `dcm_classifier` package. This block attempts to set `__version__` using `importlib.metadata.version("dcm_classifier")`. If a `PackageNotFoundError` is caught, it defaults `__version__` to "0.0.0-dev", facilitating development and testing workflows.

Key components:
- Modification of the `__init__.py` file to include error handling around the version import.
- This adds robustness to the development process, allowing for seamless testing and development without the package necessarily being installed.

To use this functionality, simply continue development as normal. The version handling is automatic and requires no additional steps from the developer.

# Testing
This feature was tested by:
- Automated tests that simulate an environment where the package is not installed. These tests verify that the fallback version is used as expected. Passed entire pytest suite
- Manual testing in a local development setup, confirming that the `ImportError` is resolved and development can proceed without the package installed.

# Problems Faced
Initially encountered the `ImportError` during local development, which was obstructing the ability to test and develop the codebase easily. The solution was to implement a try-except block as described, which resolved the issue without impacting the package's functionality or deployment process.

# Notes
This update is crucial for developers working on the `dcm_classifier` package, streamlining the development process by removing a common obstacle.


