### PR TITLE
Fix Acquisition Type Comparsion 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcm_classifier"
-version = '0.8.0'
+version = '0.8.1'
 authors = [
   { name="Michal Brzus", email="michal-brzus@uiowa.edu" },
   { name="Hans Johnson", email="hans-johnson@uiowa.edu" },

--- a/src/dcm_classifier/dicom_series.py
+++ b/src/dcm_classifier/dicom_series.py
@@ -261,7 +261,7 @@ class DicomSingleSeries:
         # AcquisitionTime is an optional field, this might need to be changed in the future
         sorted(
             self.volume_info_list,
-            key=lambda x: x.get_volume_dictionary().get("AcquisitionTime", -12345),
+            key=lambda x: x.get_volume_dictionary().get("AcquisitionTime", "000000.00"),
         )
         # assign the index to each volume
         for index, volume in enumerate(self.volume_info_list):

--- a/src/dcm_classifier/utility_functions.py
+++ b/src/dcm_classifier/utility_functions.py
@@ -585,7 +585,7 @@ def sanitize_dicom_dataset(
         elif field == "AcquisitionTime":
             if field not in dataset:
                 # AcquisitionTime is not a required field, it can be unknown
-                _default_inferred_value = -12345
+                _default_inferred_value = "000000.00"
                 dataset_dictionary[field] = _default_inferred_value
                 vprint(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"


### PR DESCRIPTION
# Overview

This pull request fixes the bug when the classifier attempts to organize dicom volumes by AcquisitionTime by converting the default sanitized value for the field into a string.

# Implementation
<!--
_What items were implemented?_
_What are their key components and functionality?_
_What does this add to the overall project?_
_How do you use this new functionality? (if applicable)_
-->
Default sanitization value is set to the string 000000.00 so comparison will not fail on comparing strings and ints.

# Testing
<!--
_How was this feature tested?_
_What automated tests were used?_
_What manual tests were used?_
_Where are these documented?_
-->
Classifier was tested and outputs were as expected.

# Problems Faced
<!-- _Did you run into any problems, if so how did you resolve them? -->
N/A

# Notes
<!--
_Any screenshots/videos demonstrating the functioning of the changes made in this pull request?_
_Is there any other important notes related to this pull request?

-->
N/A
