### PR TITLE
Fix missing field failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcm_classifier"
-version = '0.8.2'
+version = '0.8.3'
 authors = [
   { name="Michal Brzus", email="michal-brzus@uiowa.edu" },
   { name="Hans Johnson", email="hans-johnson@uiowa.edu" },


### PR DESCRIPTION
# Overview
If dicom header fields are missing, provide defaults to avoid failure.

# Implementation
```python
>>>>
- self._pydicom_info.FIELDNAME
====
+ self._pydicom_info.get("FIELDNAME", "UNKNOWN_FIELDNAME")
<<<<
```

