### PR TITLE
Readthedocs deployment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,6 +25,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+   install:
+   - requirements: docs/requirements-docs.txt

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,2 @@
+sphinx==7.3.6
+sphinx_rtd_theme==2.0.0


### PR DESCRIPTION
# Overview
<!-- _What is the purpose of this pull request?_ -->

Read the docs builds the docs on their servers to host on their website. Therefore we need to provide the requirements path to the readthedocs config yaml file so the environment created during the documentation build will have correct packages needed for our documentation