### PR TITLE
Automatically Scale Dicom Image's

### DIFF
--- a/src/dcm_classifier/dicom_volume.py
+++ b/src/dcm_classifier/dicom_volume.py
@@ -315,7 +315,12 @@ class DicomSingleVolumeInfoBase:
 
     def get_itk_image(self, apply_dcm_scaling_info: bool = True) -> FImageType:
         """
-        Get the ITK image associated with the DICOM volume.
+            Get the ITK image associated with the DICOM volume.
+            If no image is available, it will be read from the DICOM files
+            and optionally scaled based on the apply_dcm_scaling_info value.
+
+        Args:
+            apply_dcm_scaling_info (bool, optional): A flag indicating whether to apply the scaling information from the DICOM header to the ITK image. Defaults to True.
 
         Returns:
             FImageType: The ITK image of the DICOM volume with pixel type itk.F (float).

--- a/src/dcm_classifier/example_image_processing.py
+++ b/src/dcm_classifier/example_image_processing.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 import numpy as np
 import pydicom
-from .utility_functions import get_bvalue, itk_read_from_dicomfn_list
+from .utility_functions import (
+    get_bvalue,
+    itk_read_from_dicomfn_list,
+    add_const_to_itk_images,
+    multiply_itk_images,
+)
 from .dicom_series import DicomSingleSeries
 
 
@@ -508,25 +513,6 @@ def add_itk_images(im1: FImageType, im2: FImageType) -> FImageType:
     return sum_image_filter.GetOutput()
 
 
-def add_const_to_itk_images(im1: FImageType, offset: float) -> FImageType:
-    """
-    Add a constant offset to all pixel values in the input image.
-
-    Args:
-        im1 (FImageType): The input image.
-
-        offset (float): The constant offset to be added to each pixel value.
-
-    Returns:
-        FImageType: The image with the constant offset added to its pixel values.
-    """
-    sum_image_filter = itk.AddImageFilter[FImageType, FImageType, FImageType].New()
-    sum_image_filter.SetInput(im1)
-    sum_image_filter.SetConstant(offset)
-    sum_image_filter.Update()
-    return sum_image_filter.GetOutput()
-
-
 def sub_itk_images(im1: FImageType, im2: FImageType) -> FImageType:
     """
     Subtract pixel values of the second input image from the first input image element-wise.
@@ -565,29 +551,6 @@ def div_itk_images(im1: FImageType, im2: FImageType) -> FImageType:
     div_image_filter.SetInput2(im2)
     div_image_filter.Update()
     return div_image_filter.GetOutput()
-
-
-def multiply_itk_images(im1: FImageType, scale: float) -> FImageType:
-    """
-    Multiply all pixel values in the input image by a constant scale.
-
-    Args:
-        im1 (FImageType): The input image.
-
-        scale (float): The constant scale factor to multiply each pixel value.
-
-    Returns:
-        FImageType: The image with pixel values multiplied by the specified scale factor.
-    """
-
-    # TODO: Add inplace computations for speed
-    mult_image_filter = itk.MultiplyImageFilter[
-        FImageType, FImageType, FImageType
-    ].New()
-    mult_image_filter.SetInput(im1)
-    mult_image_filter.SetConstant(scale)
-    mult_image_filter.Update()
-    return mult_image_filter.GetOutput()
 
 
 def add_list_of_images(list_of_images: list[FImageType]) -> FImageType:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import re
-import subprocess
 import pytest
 from pathlib import Path
 

--- a/tests/unit_testing/test_dicom_volume.py
+++ b/tests/unit_testing/test_dicom_volume.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pandas as pd
 from dcm_classifier.dicom_volume import (
     DicomSingleVolumeInfoBase,
 )


### PR DESCRIPTION
# Overview
When the valid fields are provided we should prefer to apply the provided scaling information at time of conversion from dcm to itk. Most of the time there is no scaling information provided and no scaling is done. 


# Implementation
When calling the `get_itk_image` function we check to see if there are the appropriate scaling dicom headers
It then extracts the scaling information out of the provided headers and applies them to the newly generated ITK image

# Testing
This was manually tested on over 800 prostate studies with promising results. 
There are No Unit tests as of yet

# Problems Faced
None 

# Notes
For more information please refer [here](https://github.com/rordenlab/dcm2niix/tree/master/Philips)
