### PR TITLE
BUG: Non-zero bvalue single volumes listed as t2w

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcm_classifier"
-version = '0.9.0'
+version = '0.9.1'
 authors = [
   { name="Michal Brzus", email="michal-brzus@uiowa.edu" },
   { name="Hans Johnson", email="hans-johnson@uiowa.edu" },

--- a/src/dcm_classifier/image_type_inference.py
+++ b/src/dcm_classifier/image_type_inference.py
@@ -379,6 +379,10 @@ class ImageTypeClassifierBase:
             modality = volume.get_volume_modality().replace("LOW_PROBABILITY_", "")
 
             self.series.set_series_modality(modality)
+            bval = volume.get_volume_bvalue()
+            if bval > 0 and modality not in ["tracew", "adc", "fa", "eadc", "dwig"]:
+                self._update_diffusion_series_modality()
+
             self.series.set_modality_probabilities(volume.get_modality_probabilities())
             self.series.set_acquisition_plane(volume.get_acquisition_plane())
             self.series.set_is_isotropic(volume.get_is_isotropic())


### PR DESCRIPTION

# Overview
Logic used to re-characterize t2w -> tracew in multi-volumes needed to be employed in single volume cases.


# Testing
pytests all pass.

# Problems Faced
Single volume tracew that have very similar characteristics to T2w, but have positive bvalues.

