### PR TITLE
implement same itk image spacing function

### DIFF
--- a/src/dcm_classifier/study_processing.py
+++ b/src/dcm_classifier/study_processing.py
@@ -239,6 +239,15 @@ class ProcessOneDicomStudyToVolumesMappingBase:
         self.fixup_adjacent_series()
 
     def fixup_adjacent_series(self):
+        """
+        Fix up adjacent series that are part of the same family of images.
+
+        This method iterates through the DICOM series stored in the class's series_dictionary
+        and fixes up cases where adjacent series are part of the same family of images. It
+        checks for cases where a bvalue=0 image is part of a family of tracew images and
+        updates the series modality to "tracew" for the adjacent series.
+
+        """
         # Fix up case where adjacent volumes make up a family of tracew images and one of them is a bvalue=0 image
         for current_series_number, series_obj in self.get_study_dictionary().items():
             if series_obj.get_volume_list()[

--- a/src/dcm_classifier/study_processing.py
+++ b/src/dcm_classifier/study_processing.py
@@ -22,6 +22,7 @@ import itk
 from .dicom_volume import DicomSingleVolumeInfoBase
 from .dicom_series import DicomSingleSeries
 from .image_type_inference import ImageTypeClassifierBase
+from .utility_functions import check_two_images_have_same_physical_space
 
 
 class ProcessOneDicomStudyToVolumesMappingBase:
@@ -271,29 +272,13 @@ class ProcessOneDicomStudyToVolumesMappingBase:
                                     ].get_itk_image()
                                 )
 
-                                same_size: bool = (
-                                    itk_volume.GetLargestPossibleRegion().GetSize()
-                                    == itk_adjacent_volume.GetLargestPossibleRegion().GetSize()
-                                )
-                                same_space: bool = (
-                                    itk_volume.GetSpacing()
-                                    == itk_adjacent_volume.GetSpacing()
-                                )
-                                same_origin: bool = (
-                                    itk_volume.GetOrigin()
-                                    == itk_adjacent_volume.GetOrigin()
-                                )
-                                same_direction: bool = (
-                                    itk_volume.GetDirection()
-                                    == itk_adjacent_volume.GetDirection()
+                                same_physical_space: bool = (
+                                    check_two_images_have_same_physical_space(
+                                        itk_volume, itk_adjacent_volume
+                                    )
                                 )
 
-                                if (
-                                    same_size
-                                    and same_space
-                                    and same_origin
-                                    and same_direction
-                                ):
+                                if same_physical_space:
                                     series_obj.set_series_modality("tracew")
                                 else:
                                     print(

--- a/src/dcm_classifier/utility_functions.py
+++ b/src/dcm_classifier/utility_functions.py
@@ -776,6 +776,17 @@ def convert_array_to_index_value(name: str, value_list: MultiValue | ndarray) ->
 def check_two_images_have_same_physical_space(
     img1: FImageType, img2: FImageType
 ) -> bool:
+    """
+    Check if two images have the same physical space.
+
+    :param img1: The first image.
+    :type img1: FImageType
+    :param img2: The second image.
+    :type img2: FImageType
+    :return: True if the images have the same physical space, False otherwise.
+    :rtype: bool
+
+    """
     same_size: bool = (
         img1.GetLargestPossibleRegion().GetSize()
         == img2.GetLargestPossibleRegion().GetSize()

--- a/src/dcm_classifier/utility_functions.py
+++ b/src/dcm_classifier/utility_functions.py
@@ -771,3 +771,17 @@ def convert_array_to_index_value(name: str, value_list: MultiValue | ndarray) ->
     for index in range(0, len(number_list)):
         named_list.append((name + "_" + str(index), number_list[index]))
     return named_list
+
+
+def check_two_images_have_same_physical_space(
+    img1: FImageType, img2: FImageType
+) -> bool:
+    same_size: bool = (
+        img1.GetLargestPossibleRegion().GetSize()
+        == img2.GetLargestPossibleRegion().GetSize()
+    )
+    same_space: bool = img1.GetSpacing() == img2.GetSpacing()
+    same_origin: bool = img1.GetOrigin() == img2.GetOrigin()
+    same_direction: bool = img1.GetDirection() == img2.GetDirection()
+
+    return same_size and same_space and same_origin and same_direction


### PR DESCRIPTION
# Overview
<!-- _What is the purpose of this pull request?_ -->
The purpose of this pull request is to make the logic of checking if two ITK images have the same physical space into its own utility function.

# Implementation
<!--
_What items were implemented?_
_What are their key components and functionality?_
_What does this add to the overall project?_
_How do you use this new functionality? (if applicable)_
-->
Logic for physical space comparison was taken from the fixup_adjacent_series method and made into its own callable utility function.

# Testing
<!--
_How was this feature tested?_
_What automated tests were used?_
_What manual tests were used?_
_Where are these documented?_
-->
Manual testing using the classify study script was run on existing data sets and outputs were as expected.

# Problems Faced
<!-- _Did you run into any problems, if so how did you resolve them? -->
N/A

# Notes
<!--
_Any screenshots/videos demonstrating the functioning of the changes made in this pull request?_
_Is there any other important notes related to this pull request?

-->
N/A
