### PR TITLE
59 correct series invalidity

### DIFF
--- a/.github/workflows/pr_to_main.yml
+++ b/.github/workflows/pr_to_main.yml
@@ -26,19 +26,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          pip install sphinx sphinx-rtd-theme  # Install Sphinx and a theme (e.g., Read the Docs theme)
 
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
 
       - name: Run tests
         working-directory: ./tests
-        run: pytest -rP
-         # git lfs fetch --all
-          #pytest
-
-#          export PYTHONPATH="${PYTHONPATH}:$(dirname $(pwd))"
-
-#      - name: Build documentation with Sphinx
-#        run: |
-#          sphinx-build -b html src/dcm_classifier documentation
+        run: pytest

--- a/.github/workflows/pr_to_main.yml
+++ b/.github/workflows/pr_to_main.yml
@@ -13,7 +13,9 @@ jobs:
           lfs: true  # Ensure LFS files are checked out
 
       - name: Install Git LFS
-        run: git lfs install
+        run: |
+          git lfs install
+          git lfs pull
 
       - name: Set up Python 3.10.12
         uses: actions/setup-python@v2
@@ -31,7 +33,7 @@ jobs:
 
       - name: Run tests
         working-directory: ./tests
-        run: pytest
+        run: pytest -rP
          # git lfs fetch --all
           #pytest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcm_classifier"
-version = '0.9.1'
+version = '0.9.4'
 authors = [
   { name="Michal Brzus", email="michal-brzus@uiowa.edu" },
   { name="Hans Johnson", email="hans-johnson@uiowa.edu" },

--- a/src/dcm_classifier/utility_functions.py
+++ b/src/dcm_classifier/utility_functions.py
@@ -451,22 +451,33 @@ def sanitize_dicom_dataset(
 
     # set the default values for optional dicom fields
     for field in optional_info_list:
+        DEFAULT_VALUE = -12345
+        dataset_dictionary[field] = (
+            DEFAULT_VALUE  # Every optional field will be set to the default -12345 and will be overriden if present and valid
+        )
+        try:
+            dataset_value = dataset[field].value
+        except Exception:
+            dataset_value = DEFAULT_VALUE
+
         if field == "SAR":
-            if field not in dataset or not is_number(dataset[field].value):
+            if field not in dataset or not is_number(dataset_value):
                 # SAR is allowed to be empty or not a number because derived images often do not have SAR
                 # for example, ADC images are derived images that are computed, so there is not
                 # SAR impact on the patient for the derived image.
                 # SAR Calculated whole body Specific Absorption Rate in watts/kilogram.
                 # indicate that there is no SAR for the computed image
-                _default_inferred_value = -12345.0
+                _default_inferred_value = DEFAULT_VALUE
                 dataset_dictionary[field] = _default_inferred_value
                 vprint(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = validate_numerical_dataset_element(
+                    dataset_value
+                )
         elif field == "Manufacturer":
-            if field not in dataset:
+            if field not in dataset or dataset_value is None:
                 # Manufacturer is not a required field, it can be unknown
                 _default_inferred_value = "UnknownManufacturer"
                 dataset_dictionary[field] = _default_inferred_value
@@ -474,9 +485,9 @@ def sanitize_dicom_dataset(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = dataset_value
         elif field == "ImageType":
-            if field not in dataset:
+            if field not in dataset or dataset_value is None:
                 # ImageType is not a required field, it can be unknown
                 _default_inferred_value = "UnknownImageType"
                 dataset_dictionary[field] = _default_inferred_value
@@ -484,39 +495,39 @@ def sanitize_dicom_dataset(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = dataset_value
         elif field == "ContrastBolusAgent":
-            if field not in dataset:
-                # if (
-                #     dataset_dictionary[field] is None
-                #     or str(dataset_dictionary[field]) == ""
-                # ):
+            if field not in dataset or dataset_value is None:
                 # The contrast is required but is empty if unknown but also may not be in every dataset
-                dataset_dictionary[field] = "None"
+                dataset_dictionary[field] = DEFAULT_VALUE
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = dataset_value
         elif field == "EchoNumbers":
             if field not in dataset:
                 # EchoNumber(s) is not a required field, it can be unknown
-                _default_inferred_value = -12345
+                _default_inferred_value = DEFAULT_VALUE
                 dataset_dictionary[field] = _default_inferred_value
                 vprint(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = validate_numerical_dataset_element(
+                    dataset_value
+                )
         elif field == "EchoTrainLength":
             if field not in dataset:
                 # EchoTrainLength is not a required field, it can be unknown
-                _default_inferred_value = -12345
+                _default_inferred_value = DEFAULT_VALUE
                 dataset_dictionary[field] = _default_inferred_value
                 vprint(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = validate_numerical_dataset_element(
+                    dataset_value
+                )
         elif field == "ScanningSequence":
-            if field not in dataset:
+            if field not in dataset or dataset_value is None:
                 # ScanningSequence is not a required field, it can be unknown
                 _default_inferred_value = "UnknownScanningSequence"
                 dataset_dictionary[field] = _default_inferred_value
@@ -524,9 +535,9 @@ def sanitize_dicom_dataset(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = dataset_value
         elif field == "SequenceVariant":
-            if field not in dataset:
+            if field not in dataset or dataset_value is None:
                 # SequenceVariant is not a required field, it can be unknown
                 _default_inferred_value = "UnknownSequenceVariant"
                 dataset_dictionary[field] = _default_inferred_value
@@ -534,9 +545,9 @@ def sanitize_dicom_dataset(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = dataset_value
         elif field == "InPlanePhaseEncodingDirection":
-            if field not in dataset:
+            if field not in dataset or dataset_value is None:
                 # InplanePhaseEncodingDirection is not a required field, it can be unknown
                 _default_inferred_value = "UnknownInplanePhaseEncodingDirection"
                 dataset_dictionary[field] = _default_inferred_value
@@ -544,29 +555,33 @@ def sanitize_dicom_dataset(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = dataset_value
         elif field == "dBdt":
             if field not in dataset:
                 # dBdt is not a required field, it can be unknown
-                _default_inferred_value = -12345
+                _default_inferred_value = DEFAULT_VALUE
                 dataset_dictionary[field] = _default_inferred_value
                 vprint(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = validate_numerical_dataset_element(
+                    dataset_value
+                )
         elif field == "ImagingFrequency":
             if field not in dataset:
                 # ImagingFrequency is not a required field, it can be unknown
-                _default_inferred_value = -12345
+                _default_inferred_value = DEFAULT_VALUE
                 dataset_dictionary[field] = _default_inferred_value
                 vprint(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = validate_numerical_dataset_element(
+                    dataset_value
+                )
         elif field == "MRAcquisitionType":
-            if field not in dataset:
+            if field not in dataset or dataset_value is None:
                 # MRAcquisitionType is not a required field, it can be unknown
                 _default_inferred_value = "UnknownMRAcquisitionType"
                 dataset_dictionary[field] = _default_inferred_value
@@ -574,29 +589,33 @@ def sanitize_dicom_dataset(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = dataset_value
         elif field == "NumberOfAverages":
             if field not in dataset:
                 # NumberOfAverages is not a required field, it can be unknown
-                _default_inferred_value = -12345
+                _default_inferred_value = DEFAULT_VALUE
                 dataset_dictionary[field] = _default_inferred_value
                 vprint(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = validate_numerical_dataset_element(
+                    dataset_value
+                )
         elif field == "InversionTime":
             if field not in dataset:
                 # InversionTime is not a required field, it can be unknown
-                _default_inferred_value = -12345
+                _default_inferred_value = DEFAULT_VALUE
                 dataset_dictionary[field] = _default_inferred_value
                 vprint(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = validate_numerical_dataset_element(
+                    dataset_value
+                )
         elif field == "VariableFlipAngleFlag":
-            if field not in dataset:
+            if field not in dataset or dataset_value is None:
                 # VariableFlipAngleFlag is not a required field, it can be unknown
                 _default_inferred_value = "UnknownVariableFlipAngleFlag"
                 dataset_dictionary[field] = _default_inferred_value
@@ -604,7 +623,7 @@ def sanitize_dicom_dataset(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = dataset_value
         elif field == "AcquisitionTime":
             if field not in dataset:
                 # AcquisitionTime is not a required field, it can be unknown
@@ -614,7 +633,9 @@ def sanitize_dicom_dataset(
                     f"Inferring optional {field} value of '{_default_inferred_value}' for missing field in {dicom_filename}"
                 )
             else:
-                dataset_dictionary[field] = dataset[field].value
+                dataset_dictionary[field] = validate_numerical_dataset_element(
+                    dataset_value
+                )
 
     # Warn the user if there are INVALID_VALUE fields
     if len(missing_fields) > 0:
@@ -625,6 +646,23 @@ def sanitize_dicom_dataset(
         return dataset_dictionary, False
 
     return dataset_dictionary, True
+
+
+def validate_numerical_dataset_element(element: str | None) -> str | float:
+    """
+    Function to validate element can be converted to a float
+
+    :param element: The element to validate.
+    :type element: str
+
+    :return: The element as a float if it can be converted, otherwise the element as a string.
+    :rtype: str | float
+    """
+    try:
+        float(element)
+        return element
+    except Exception:
+        return -12345
 
 
 # organize required features
@@ -715,7 +753,7 @@ def get_coded_dictionary_elements(
                 else:
                     dataset_dictionary[feature] = 0
         elif name == "ContrastBolusAgent":
-            no_contrast_list = ["none", "no", "no contrast", "no_contrast", "n"]
+            no_contrast_list = ["none", "no", "no contrast", "no_contrast", "n", ""]
             if str(value).lower() in no_contrast_list:
                 dataset_dictionary["ContrastBolusAgent"] = "None"
             else:

--- a/tests/testing_data/anonymized_testing_data/empty_data_fields/empty_fields.dcm
+++ b/tests/testing_data/anonymized_testing_data/empty_data_fields/empty_fields.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb9bce258812ceba0650e03acf5bea15c05d5405f06aa6e98be7d6145ec0fba2
+size 64876

--- a/tests/unit_testing/test_dicom_volume.py
+++ b/tests/unit_testing/test_dicom_volume.py
@@ -223,6 +223,30 @@ def test_dcm_vol_no_contrast(no_contrast_file_path):
         assert series.get_volume_list()[0].get_contrast_agent() == "None"
 
 
+def test_dataset_value_set_to_none(get_data_dir):
+    file_path = get_data_dir.parent / "empty_data_fields"
+    assert file_path.exists()
+
+    study = ProcessOneDicomStudyToVolumesMappingBase(
+        study_directory=file_path, inferer=inferer
+    )
+    study.run_inference()
+
+    series = study.get_study_dictionary().get(1)
+
+    assert series.get_has_contrast() is False
+
+    assert series.get_volume_list()[0].get_volume_modality() == "gret2star"
+    assert (
+        series.get_volume_list()[0].get_volume_dictionary()["ContrastBolusAgent"]
+        == "None"
+    )
+    assert (
+        series.get_volume_list()[0].get_volume_dictionary()["InversionTime"] == "-12345"
+    )
+    assert series.get_volume_list()[0].get_volume_dictionary()["SAR"] == "-12345"
+
+
 def test_t1w_dcm_volume_modality(mock_volume_study):
     for series_num, series in mock_volume_study.get_study_dictionary().items():
         for volume in series.get_volume_list():

--- a/tests/unit_testing/test_utility_functions.py
+++ b/tests/unit_testing/test_utility_functions.py
@@ -15,6 +15,7 @@ from dcm_classifier.utility_functions import (
     convert_array_to_index_value,
     get_coded_dictionary_elements,
     get_bvalue,
+    validate_numerical_dataset_element,
 )
 from dcm_classifier.dicom_config import required_DICOM_fields, optional_DICOM_fields
 from pathlib import Path
@@ -329,6 +330,17 @@ def test_get_gradient_direction(get_data_dir):
         get_diffusion_gradient_direction(ds_w_grad), ds_w_grad[(0x0019, 0x100E)].value
     ):
         assert elem[0] == elem[1]
+
+
+def test_validating_numerical_dataset():
+    element = validate_numerical_dataset_element("1.0")
+    assert element == "1.0"
+
+    element = validate_numerical_dataset_element("None")
+    assert element == -12345
+
+    element = validate_numerical_dataset_element(None)
+    assert element == -12345
 
 
 def test_is_integer():

--- a/tests/unit_testing/test_utility_functions.py
+++ b/tests/unit_testing/test_utility_functions.py
@@ -322,13 +322,17 @@ def test_get_gradient_direction(get_data_dir):
 
     # testing gradient direction
     grad_dir = get_data_dir.parent / "anonymized_dwi_series" / "DICOM"
-    grad = list(grad_dir.rglob("*.dcm"))[0]
-    ds_w_grad = pydicom.dcmread(grad)
+    grad = (
+        grad_dir
+        / "1.3.12.2.1107.5.1.4.91493331060615608073226796366526631566-2-4-j1vatm.dcm"
+    )
+
+    ds_w_grad = pydicom.dcmread(grad.as_posix())
 
     # ensure each element in the diffusion gradient direction is equal to the value in the DICOM header
-    for elem in zip(
-        get_diffusion_gradient_direction(ds_w_grad), ds_w_grad[(0x0019, 0x100E)].value
-    ):
+    dataset_grad = ds_w_grad[0x0019100E].value
+
+    for elem in zip(get_diffusion_gradient_direction(ds_w_grad), dataset_grad):
         assert elem[0] == elem[1]
 
 


### PR DESCRIPTION
# Overview
<!-- _What is the purpose of this pull request?_ -->
This pull request addresses a bug where invalid inputs to non-required fields are not being caught, resulting in an "INVALID" modality classification error.

# Implementation
<!--
_What items were implemented?_
_What are their key components and functionality?_
_What does this add to the overall project?_
_How do you use this new functionality? (if applicable)_
-->
* Input Validation: Implemented a validation check for non-required fields to ensure that any invalid inputs are sanitized or ignored with a default value before processing.
* Error Handling: Added error handling to catch and manage cases where invalid inputs were previously causing the system to classify the modality as "INVALID." Inputs that are numerical are verified to be able to convert to floats.  

# Testing
<!--
_How was this feature tested?_
_What automated tests were used?_
_What manual tests were used?_
_Where are these documented?_
-->
* Automated Tests: Updated and added new unit tests to cover scenarios involving invalid or empty inputs in non-required fields.
* Manual Testing: Performed manual testing using an anonymized dataset to verify that invalid inputs are now properly handled without causing modality classification errors.

# Problems Faced
<!-- _Did you run into any problems, if so how did you resolve them? -->
There were issues deciding upon what was the best way to catch cases with optional input fields that were empty. We decided to initialize every optional value in the data set dictionary with a default empty value and overrode the value if provided.
# Notes
<!--
_Any screenshots/videos demonstrating the functioning of the changes made in this pull request?_
_Is there any other important notes related to this pull request?

-->
N/A