### PR TITLE
Remove redundant subvolume identification

### DIFF
--- a/src/dcm_classifier/study_processing.py
+++ b/src/dcm_classifier/study_processing.py
@@ -327,12 +327,6 @@ class ProcessOneDicomStudyToVolumesMappingBase:
         namesGenerator.SetUseSeriesDetails(True)
         namesGenerator.SetLoadPrivateTags(True)
         namesGenerator.SetRecursive(True)
-        for (
-            bvalue_restrictions
-        ) in (
-            ProcessOneDicomStudyToVolumesMappingBase.series_restrictions_list_dwi_subvolumes
-        ):
-            namesGenerator.AddSeriesRestriction(bvalue_restrictions)
         # namesGenerator.AddSeriesRestriction("0008|0021")  # Date restriction
         # namesGenerator.AddSeriesRestriction("0020|0013") # For testing, SeriesInstance results in images with 1 value
         namesGenerator.SetGlobalWarningDisplay(False)

--- a/src/dcm_classifier/study_processing.py
+++ b/src/dcm_classifier/study_processing.py
@@ -350,7 +350,7 @@ class ProcessOneDicomStudyToVolumesMappingBase:
                 )
         else:
             print(
-                f"The directory: {study_directory} contains {len(seriesUID)} DICOM sub-volumes"
+                f"The directory: {study_directory} contains {len(seriesUID)} DICOM series"
             )
         # print(f"Contains the following {len(seriesUID)} DICOM Series: ")
         # for uid in seriesUID:
@@ -371,11 +371,13 @@ class ProcessOneDicomStudyToVolumesMappingBase:
             )
 
             # Organize these sub-volumes by their SeriesNumber
+            sn: int = -1
             for volume_obj in sub_volumes:
                 sn = volume_obj.get_series_number()
                 if sn not in volumes_dictionary:
                     volumes_dictionary[sn] = DicomSingleSeries(series_number=sn)
                 volumes_dictionary[sn].add_volume_to_series(volume_obj)
+            print(f"\t{sn} has {len(sub_volumes)} subvolumes")
 
         # Optionally filter to only the user-requested series numbers
         if self.search_series is not None:


### PR DESCRIPTION
# Overview
Remove redundant criteria for splitting volumes into sub-volumes.  The redundant criteria can be very misleading for understanding how the subvolumes are being identified.

The value splitting only works if each series has only one sub-volume with a particular bvalue.

# Implementation
Remove redundant criteria to split sub-volumes based on values.

# Notes
Subvolumes are being split only on their ImagePositionPatient and scan order (scan time, accession number) orderings.
