### PR TITLE
Deprecate specialized dicom getters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+deprecation==2.1.0
 itk>=5.3.0
 itk-core>=5.3.0
 itk-filtering>=5.3.0

--- a/src/dcm_classifier/dicom_series.py
+++ b/src/dcm_classifier/dicom_series.py
@@ -280,6 +280,9 @@ class DicomSingleSeries:
         Get the series instance UID of the DICOM series.
         This should be the same for all volumes and is picked from the first volume.
 
+        .. deprecated:: 0.9.6
+         This method is deprecated. Use get_dicom_field_by_name instead.
+
         :return: The series instance UID.
         :rtype: str
         """
@@ -293,6 +296,9 @@ class DicomSingleSeries:
         """
         Get the Study Instance UID of the DICOM series.
         This should be the same for all volumes and is picked from the first volume.
+
+        .. deprecated:: 0.9.6
+         This method is deprecated. Use get_dicom_field_by_name instead.
 
         :return: The Study Instance UID.
         :rtype: str

--- a/src/dcm_classifier/dicom_series.py
+++ b/src/dcm_classifier/dicom_series.py
@@ -15,6 +15,7 @@
 #    limitations under the License.
 #
 #  =========================================================================
+from deprecation import deprecated
 
 from .dicom_volume import DicomSingleVolumeInfoBase
 import pandas as pd
@@ -270,6 +271,10 @@ class DicomSingleSeries:
         """
         return self.volume_info_list[0].get_dicom_field_by_name(field_name)
 
+    @deprecated(
+        deprecated_in="0.9.6",
+        details="Use generic `get_dicom_field_by_name(field_name='SeriesInstanceUID')` instead of `get_series_uid()`",
+    )
     def get_series_uid(self) -> str:
         """
         Get the series instance UID of the DICOM series.
@@ -280,6 +285,10 @@ class DicomSingleSeries:
         """
         return self.volume_info_list[0].get_series_uid()
 
+    @deprecated(
+        deprecated_in="0.9.6",
+        details="Use generic `get_dicom_field_by_name(field_name='StudyInstanceUID')` instead of `get_study_uid()`",
+    )
     def get_study_uid(self) -> str:
         """
         Get the Study Instance UID of the DICOM series.

--- a/src/dcm_classifier/dicom_volume.py
+++ b/src/dcm_classifier/dicom_volume.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pandas as pd
 import json
 from copy import deepcopy
-
+from deprecation import deprecated
 from typing import Any
 import pydicom
 from .utility_functions import (
@@ -125,6 +125,10 @@ class DicomSingleVolumeInfoBase:
             self.volume_info_dict,
         ) = self._make_one_study_info_mapping_from_filelist()
 
+    @deprecated(
+        deprecated_in="0.9.6",
+        details="Use generic `get_dicom_field_by_name(field_name='SeriesDescription')` instead of `get_volume_series_description()`",
+    )
     def get_volume_series_description(self) -> str:
         """
         Get the Series Description of the DICOM volume.
@@ -205,13 +209,11 @@ class DicomSingleVolumeInfoBase:
         """
         Retrieves the contrast agent of the DICOM data.
 
-        :return: The contrast agent.
+        :return: The contrast agent if available.
         :rtype: str
         """
         if self.get_has_contrast():
-            return self._pydicom_info.get(
-                "ContrastBolusAgent", "UNKNOWN_ContrastBolusAgent"
-            )
+            return self.get_dicom_field_by_name(field_name="ContrastBolusAgent")
         else:
             return "None"
 
@@ -340,6 +342,10 @@ class DicomSingleVolumeInfoBase:
         """
         return self._pydicom_info.get(field_name, f"UNKNOWN_{field_name}")
 
+    @deprecated(
+        deprecated_in="0.9.6",
+        details="Use generic `get_dicom_field_by_name(field_name='SeriesInstanceUID')` instead of `get_series_uid()`",
+    )
     def get_series_uid(self) -> str:
         """
         Get the Series Instance UID of the DICOM volume.
@@ -349,6 +355,10 @@ class DicomSingleVolumeInfoBase:
         """
         return self._pydicom_info.get("SeriesInstanceUID", "UNKNOWN_SeriesInstanceUID")
 
+    @deprecated(
+        deprecated_in="0.9.6",
+        details="Use generic `get_dicom_field_by_name(field_name='StudyInstanceUID')` instead of `get_study_uid()`",
+    )
     def get_study_uid(self) -> str:
         """
         Get the Study Instance UID of the DICOM volume.
@@ -358,6 +368,10 @@ class DicomSingleVolumeInfoBase:
         """
         return self._pydicom_info.get("StudyInstanceUID", "UNKNOWN_StudyInstanceUID")
 
+    @deprecated(
+        deprecated_in="0.9.6",
+        details="Use generic `get_dicom_field_by_name(field_name='PixelSpacing')` instead of `get_series_pixel_spacing()`",
+    )
     def get_series_pixel_spacing(self) -> str:
         """
         Get the pixel spacing of the DICOM series.
@@ -409,6 +423,10 @@ class DicomSingleVolumeInfoBase:
         """
         return self.bvalue
 
+    @deprecated(
+        deprecated_in="0.9.6",
+        details="Use generic `get_dicom_field_by_name(field_name='SeriesNumber')` instead of `get_series_number()`",
+    )
     def get_series_number(self) -> int:
         """
         Get the Series Number of the DICOM volume.
@@ -480,7 +498,7 @@ class DicomSingleVolumeInfoBase:
         if not valid:
             self.set_volume_modality("INVALID")
             self.set_acquisition_plane("INVALID")
-            return self.get_study_uid, dict()
+            return self.get_dicom_field_by_name(field_name="StudyInstanceUID"), dict()
 
         volume_info_dict: dict[str, Any] = get_coded_dictionary_elements(
             sanitized_dicom_dict
@@ -489,7 +507,7 @@ class DicomSingleVolumeInfoBase:
 
         # ensure the volume_info_dict is not empty
         if not volume_info_dict:
-            return self.get_study_uid, dict()
+            return self.get_dicom_field_by_name(field_name="StudyInstanceUID"), dict()
 
         # add features related to b-values and diffusion
         bvalue_current_dicom: int = int(self.get_volume_bvalue())
@@ -519,7 +537,9 @@ class DicomSingleVolumeInfoBase:
         # add list of dicom files for the volume
         volume_info_dict["list_of_ordered_volume_files"] = self.one_volume_dcm_filenames
 
-        return self.get_study_uid, deepcopy(volume_info_dict)
+        return self.get_dicom_field_by_name(field_name="StudyInstanceUID"), deepcopy(
+            volume_info_dict
+        )
 
     def get_image_diagnostics(self) -> str:
         """

--- a/src/dcm_classifier/dicom_volume.py
+++ b/src/dcm_classifier/dicom_volume.py
@@ -133,6 +133,9 @@ class DicomSingleVolumeInfoBase:
         """
         Get the Series Description of the DICOM volume.
 
+        .. deprecated:: 0.9.6
+         This is a deprecated method. Use get_dicom_field_by_name instead.
+
         :return: The Series Description.
         :rtype: str
         """
@@ -331,7 +334,7 @@ class DicomSingleVolumeInfoBase:
 
     def get_dicom_field_by_name(self, field_name) -> str:
         """
-        Get the elment f"{field_name}" from the reference DICOM file (i.e. the first file found).
+        Get the element f"{field_name}" from the reference DICOM file (i.e. the first file found).
         This should be the same for all volumes and is picked from the first volume.
 
         The Keyword elements from https://github.com/pydicom/pydicom/blob/main/src/pydicom/_dicom_dict.py
@@ -350,6 +353,9 @@ class DicomSingleVolumeInfoBase:
         """
         Get the Series Instance UID of the DICOM volume.
 
+        .. deprecated:: 0.9.6
+         This is a deprecated method. Use get_dicom_field_by_name instead.
+
         :return: The Series Instance UID.
         :rtype: str
         """
@@ -363,6 +369,9 @@ class DicomSingleVolumeInfoBase:
         """
         Get the Study Instance UID of the DICOM volume.
 
+        .. deprecated:: 0.9.6
+         This is a deprecated method. Use get_dicom_field_by_name instead.
+
         :return: The Study Instance UID.
         :rtype: str
         """
@@ -375,6 +384,9 @@ class DicomSingleVolumeInfoBase:
     def get_series_pixel_spacing(self) -> str:
         """
         Get the pixel spacing of the DICOM series.
+
+        .. deprecated:: 0.9.6
+         This is a deprecated method. Use get_dicom_field_by_name instead.
 
         Returns:
             str: The pixel spacing as a string.
@@ -430,6 +442,9 @@ class DicomSingleVolumeInfoBase:
     def get_series_number(self) -> int:
         """
         Get the Series Number of the DICOM volume.
+
+        .. deprecated:: 0.9.6
+         This is a deprecated method. Use get_dicom_field_by_name instead.
 
         :return: The Series Number.
         :rtype: int

--- a/src/dcm_classifier/study_processing.py
+++ b/src/dcm_classifier/study_processing.py
@@ -367,7 +367,7 @@ class ProcessOneDicomStudyToVolumesMappingBase:
             # Organize these sub-volumes by their SeriesNumber
             sn: int = -1
             for volume_obj in sub_volumes:
-                sn = volume_obj.get_series_number()
+                sn = int(volume_obj.get_dicom_field_by_name("SeriesNumber"))
                 if sn not in volumes_dictionary:
                     volumes_dictionary[sn] = DicomSingleSeries(series_number=sn)
                 volumes_dictionary[sn].add_volume_to_series(volume_obj)

--- a/tests/unit_testing/test_dicom_series.py
+++ b/tests/unit_testing/test_dicom_series.py
@@ -5,7 +5,7 @@ from dcm_classifier.study_processing import ProcessOneDicomStudyToVolumesMapping
 from dcm_classifier.dicom_config import required_DICOM_fields, optional_DICOM_fields
 from pathlib import Path
 import pydicom
-
+from deprecation import DeprecatedWarning
 
 current_file_path = Path(__file__).parent.resolve()
 inference_model_path = list(
@@ -68,9 +68,15 @@ def test_all_fields_dont_change():
 
 
 def test_get_series_and_study_uid(mock_tracew_series):
-    for series in mock_tracew_series:
-        assert series.get_series_uid() == "2.25.200346831984180887422376003959445101633"
-        assert series.get_study_uid() == "2.25.106736773675271926686056457127502108539"
+    with pytest.warns(DeprecatedWarning, match="Use generic `get_dicom_field_by_name"):
+        for series in mock_tracew_series:
+            assert (
+                series.get_series_uid()
+                == "2.25.200346831984180887422376003959445101633"
+            )
+            assert (
+                series.get_study_uid() == "2.25.106736773675271926686056457127502108539"
+            )
 
 
 def test_series_modality_probabilities(mock_t1_series):

--- a/tests/unit_testing/test_dicom_volume.py
+++ b/tests/unit_testing/test_dicom_volume.py
@@ -8,6 +8,7 @@ import pytest
 from dcm_classifier.utility_functions import FImageType
 from dcm_classifier.study_processing import ProcessOneDicomStudyToVolumesMappingBase
 from dcm_classifier.image_type_inference import ImageTypeClassifierBase
+from deprecation import DeprecatedWarning
 
 current_file_path = Path(__file__).parent
 inference_model_path = list(
@@ -18,18 +19,21 @@ inferer = ImageTypeClassifierBase(classification_model_filename=inference_model_
 
 
 def test_get_series_uid(mock_volumes):
-    series_uid = DicomSingleVolumeInfoBase(mock_volumes[0]).get_series_uid()
-    assert series_uid == "1.2.276.0.7230010.3.1.3.168456204.6074.1606326635.433425"
+    with pytest.warns(DeprecatedWarning, match="Use generic `get_dicom_field_by_name"):
+        series_uid = DicomSingleVolumeInfoBase(mock_volumes[0]).get_series_uid()
+        assert series_uid == "1.2.276.0.7230010.3.1.3.168456204.6074.1606326635.433425"
 
 
 def test_get_series_number(mock_volumes):
-    series_number = DicomSingleVolumeInfoBase(mock_volumes[0]).get_series_number()
-    assert series_number == 700
+    with pytest.warns(DeprecatedWarning, match="Use generic `get_dicom_field_by_name"):
+        series_number = DicomSingleVolumeInfoBase(mock_volumes[0]).get_series_number()
+        assert series_number == 700
 
 
 def test_get_study_uid(mock_volumes):
-    study_uid = DicomSingleVolumeInfoBase(mock_volumes[0]).get_study_uid()
-    assert study_uid == "1.2.276.0.7230010.3.1.2.168456204.6074.1606326635.433364"
+    with pytest.warns(DeprecatedWarning, match="Use generic `get_dicom_field_by_name"):
+        study_uid = DicomSingleVolumeInfoBase(mock_volumes[0]).get_study_uid()
+        assert study_uid == "1.2.276.0.7230010.3.1.2.168456204.6074.1606326635.433364"
 
 
 def test_get_b_value(mock_volumes):
@@ -48,11 +52,12 @@ def test_primary_volume_info(mock_volumes):
 
 
 def test_get_series_pixel_spacing(mock_volumes):
-    pixel_spacing = DicomSingleVolumeInfoBase(
-        mock_volumes[0]
-    ).get_series_pixel_spacing()
-    assert isinstance(pixel_spacing, str)
-    assert pixel_spacing == "[0.9375, 0.9375]"
+    with pytest.warns(DeprecatedWarning, match="Use generic `get_dicom_field_by_name"):
+        pixel_spacing = DicomSingleVolumeInfoBase(
+            mock_volumes[0]
+        ).get_series_pixel_spacing()
+        assert isinstance(pixel_spacing, str)
+        assert pixel_spacing == "[0.9375, 0.9375]"
 
 
 # sad path, validate is False due to sentinel b-value seen in test above


### PR DESCRIPTION
# Overview
This pull request deprecates redundant, specialized DICOM getter functions (e.g., `get_series_uid`) in favor of the more versatile `get_dicom_field_by_name`. The goal is to simplify the codebase, reduce duplication, and encourage a DRY approach while maintaining backward compatibility.

# Implementation
- **Deprecation Decorator:**  
  Added a deprecation decorator (using the `deprecation` package) to mark specialized functions as deprecated. Each deprecated function now emits a clear warning (via Python’s `warnings` module) advising users to use `get_dicom_field_by_name` instead.

- **Code Refactoring:**  
  Updated internal calls to use the generic getter instead of the specialized versions, ensuring consistency and maintainability.

- **Documentation Updates:**  
  Modified docstrings of the deprecated functions to indicate their deprecation status and the alternative method to be used. Documentation and changelog entries will be updated accordingly.

- **Test Suite Enhancements:**  
  Updated automated tests to verify that deprecated functions still return the correct results and that they emit the appropriate deprecation warnings. This ensures continued backward compatibility during the transition phase.

# Testing
- **Automated Tests:**  
  Added pytest warning assertion blocks to confirm that the deprecated functions emit the correct warnings.  
  Ensured that all tests for `get_dicom_field_by_name` pass for a variety of DICOM metadata scenarios.

- **Manual Testing:**  
  Conducted manual tests by running the DICOM classification workflow with sample DICOM files to confirm that the outputs are correct and that no unexpected behavior is introduced.

# Problems Faced
- **Maintaining Backward Compatibility:**  
  One challenge was ensuring that the deprecated functions continued to operate correctly (aside from emitting warnings) until they can be fully removed.

- **Consistent Messaging:**  
  Ensuring that deprecation messages are clear, consistent, and informative across the codebase was a minor hurdle that was overcome by standardizing the decorator implementation.

# Notes
N/A