### PR TITLE
74 fix missing deprecation dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dcm_classifier"
-version = '0.9.6'
+version = '0.9.7'
 # Change Log -- Summary of key changes
+# v0.9.7 -- 2025-03-01 (git log --pretty=%s  v0.9.6..HEAD)
+#       BUG: added missing deprecation dependency to pyproject dependencies
+#       ENH: update tag version to 0.9.6
 # v0.9.6 -- 2025-02-21 (git log --pretty=%s  v0.9.5..HEAD)
 #       ENH: deprecation warning checks added to series and volume dicom field getter tests
 #       DOC: updates to docstrings for deprecated functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "deprecation>=2.1.0",
     "itk>=5.3.0",
     "itk-core>=5.3.0",
     "itk-filtering>=5.3.0",

--- a/scripts/classify_mulitiple_studies.py
+++ b/scripts/classify_mulitiple_studies.py
@@ -105,7 +105,9 @@ def process_single_study(
             except AttributeError:
                 current_dict["Bvalue"] = "None"
             try:
-                current_dict["SeriesDesc"] = volume.get_volume_series_description()
+                current_dict["SeriesDesc"] = volume.get_dicom_field_by_name(
+                    "SeriesDescription"
+                )
             except AttributeError:
                 current_dict["SeriesDesc"] = "None"
 

--- a/scripts/classify_study.py
+++ b/scripts/classify_study.py
@@ -120,7 +120,9 @@ def main():
             except AttributeError:
                 current_dict["Bvalue"] = "None"
             try:
-                current_dict["SeriesDesc"] = volume.get_volume_series_description()
+                current_dict["SeriesDesc"] = volume.get_dicom_field_by_name(
+                    "SeriesDescription"
+                )
             except AttributeError:
                 current_dict["SeriesDesc"] = "None"
             inputs_df: dict[str, Any] = volume.get_volume_dictionary()


### PR DESCRIPTION
# Overview
This pull request addresses a dependency issue that was causing a `ModuleNotFoundError` for the `deprecation` package when using `dcm_classifier`. To fix this, we've added the `deprecation` package to the `pyproject.toml` file, updated the change log, and bumped the package version to **0.9.7**. No more chasing phantom packages!

# Implementation
- **Dependency Update:** Added the `deprecation` package to `pyproject.toml` so that all required modules are installed automatically.
- **Version Bump:** Updated the package version to **0.9.7**.
- **Change Log:** Modified the change log to document the addition of the new dependency and the version update.

This change ensures that when users install `dcm_classifier`, they won't run into a missing module error. 
# Testing
- **Manual Testing:** Created a fresh virtual environment, installed `dcm_classifier`, and confirmed that the `deprecation` module is present and importable.
- **Verification:** Confirmed that no import errors occur when running the relevant test scripts.

# Problems Faced
There were no major issues— the fix was straightforward, and the update process was smooth.

# Notes
- No breaking changes were introduced with this update.
