### PR TITLE
Fix warning of wrong element keyword

### DIFF
--- a/src/dcm_classifier/dicom_config.py
+++ b/src/dcm_classifier/dicom_config.py
@@ -16,6 +16,9 @@
 #
 #  =========================================================================
 
+from pydicom import config
+
+config.INVALID_KEY_BEHAVIOR = "RAISE"
 
 """
 Dicom Configuration:

--- a/src/dcm_classifier/dicom_config.py
+++ b/src/dcm_classifier/dicom_config.py
@@ -57,8 +57,6 @@ optional_DICOM_fields: list[str] = [
     "ImageType",  # Not required
     "Manufacturer",  # Not required
     "ContrastBolusAgent",  # "(0x0018, 0x0010)"
-    "Diffusionb-value",  # Not required
-    "Diffusionb-valueMax",  # Not required
     "EchoNumbers",
     "EchoTrainLength",
     "ScanningSequence",
@@ -73,6 +71,12 @@ optional_DICOM_fields: list[str] = [
     "AcquisitionTime",
     "SeriesDescription",  # Not trustworthy, but sometimes useful
 ]
+
+# # These are not part of the DICOM dictionary.
+# optional_INFO_fields: list[str] = [
+#     "Diffusionb-value",  # Not required -- NOT A DICOM FIELD !!!
+#     "Diffusionb-valueMax",  # Not required -- NOT A DICOM FIELD!!!
+# ]
 
 inference_features: list[str] = [
     "Diffusionb-valueBool",


### PR DESCRIPTION
# Overview
Fix unnecessary warnings that make debugging other problems very difficult.

This needs to be pushed to a new version on pypi


# Implementation
Force raising error if non-dicom key value is queried.

# Testing
All pytest are currently passing.


