### PR TITLE
81 fix invalid volume classification base cataloging

### DIFF
--- a/scripts/classify_study.py
+++ b/scripts/classify_study.py
@@ -116,13 +116,13 @@ def main():
                 current_dict["Vol.#"] = "None"
 
             # Volume Modality
+            vol_modality: str = "INVALID"
             try:
-                vol_modality: str = str(volume.get_volume_modality())
+                vol_modality = str(volume.get_volume_modality())
                 current_dict["Volume Modality"] = vol_modality
-                if vol_modality != "INVALID":
-                    dictionary["VolumeModality"] = vol_modality
-                else:
+                if vol_modality == "INVALID":
                     invalid_volume = True
+                dictionary["VolumeModality"] = vol_modality
             except AttributeError:
                 current_dict["Volume Modality"] = "None"
                 dictionary = {}
@@ -131,7 +131,7 @@ def main():
             try:
                 series_modality: str = str(series.get_series_modality())
                 current_dict["Series Modality"] = series_modality
-                dictionary["SeriesModality"] = series_modality if dictionary else {}
+                dictionary["SeriesModality"] = series_modality
             except AttributeError:
                 current_dict["Series Modality"] = "None"
                 dictionary = {}
@@ -140,7 +140,7 @@ def main():
             try:
                 acq_plane: str = str(volume.get_acquisition_plane())
                 current_dict["Acq.Plane"] = acq_plane
-                dictionary["AcqPlane"] = acq_plane if dictionary else {}
+                dictionary["AcqPlane"] = acq_plane
             except AttributeError:
                 current_dict["Acq.Plane"] = "None"
                 dictionary = {}
@@ -149,22 +149,27 @@ def main():
             try:
                 isotropic: str = str(volume.get_is_isotropic())
                 current_dict["Isotropic"] = isotropic
-                dictionary["Isotropic"] = isotropic if dictionary else {}
+                dictionary["Isotropic"] = isotropic
             except AttributeError:
                 current_dict["Isotropic"] = "None"
                 dictionary["Isotropic"] = "None"
 
             # Modality Probabilities
             vol_probabilities = volume.get_modality_probabilities()
-            for col in vol_probabilities.columns:
-                # current_dict[col] = str(vol_probabilities[col].values[0])
-                if "SeriesNumber" in col or "CODE" in col:
-                    continue
-                dictionary[col] = (
-                    str(vol_probabilities[col].values[0]) if dictionary else {}
-                )
-            print(vol_probabilities.to_string(index=False))
-
+            if not invalid_volume:
+                modality_probability_dict = {}
+                for col in vol_probabilities.columns:
+                    # current_dict[col] = str(vol_probabilities[col].values[0])
+                    if "SeriesNumber" in col or "CODE" in col:
+                        continue
+                    modality_probability_dict[col] = str(
+                        vol_probabilities[col].values[0]
+                    )
+                dictionary["ModalityProbabilities"] = modality_probability_dict
+                print(vol_probabilities.to_string(index=False))
+            else:
+                # current_dict["Modality Probabilities"] = "None"
+                dictionary["ModalityProbabilities"] = "invalid_volume"
             # Bvalue
             try:
                 bval = str(volume.get_volume_bvalue())
@@ -276,9 +281,7 @@ def main():
                     shutil.copy(dcm_file, output_file_path, follow_symlinks=True)
                     # shutil.move(dcm_file, output_file_path)
             if dict_entry_name is not None:
-                session_dictionary[dict_entry_name] = (
-                    dictionary if not invalid_volume else {}  # set to empty if invalid
-                )
+                session_dictionary[dict_entry_name] = dictionary
 
     json_output_dict: dict[str, Any] = {str(args.session_directory): session_dictionary}
 


### PR DESCRIPTION
# Overview
<!-- _What is the purpose of this pull request?_ -->
Previously, when running the classify study script with the json flag, invalid volumes would be represented with an empty dictionary. That functionality is incorrect and we need the fields that are collected from each volume to be included in the JSON cataloging (especially study instance UID).

# Implementation
<!--
_What items were implemented?_
_What are their key components and functionality?_
_What does this add to the overall project?_
_How do you use this new functionality? (if applicable)_
-->
Removed the check at the end of each series' volume iteration for invalid volumes to be replaced with an empty dictionary. Additionally, made a `ModalityProbabilities` key in the volume dictionary with the modality probabilities if the volume is valid or `invalid_volume` if the volume is invalid.

# PR Checklist
<!-- _What items should be checked before this PR is considered complete?_ -->
This PR does not affect the `src` directory and does not require a new tag or update to the package, so the following checklist does not need to be fulfilled. 
- [ ] Tag your last commit.
- [ ] Update the package version in `pyproject.toml` (e.g., to 0.9.8).
- [ ] Update the changelog in `pyproject.toml` to reflect your changes.

# Testing
<!--
_How was this feature tested?_
_What automated tests were used?_
_What manual tests were used?_
_Where are these documented?_
-->
Manual testing using multiple subjects DICOM scans was conducted to ensure proper functionality. 

# Problems Faced
<!-- _Did you run into any problems, if so how did you resolve them?_ -->
N/A

# Notes
<!--
_Any screenshots/videos demonstrating the functioning of the changes made in this pull request?_
_Is there any other important notes related to this pull request?_
-->
The following is an example of an invalid volume in the JSON format:

```
        "16_0": {
            "VolumeModality": "INVALID",
            "SeriesModality": "INVALID",
            "AcqPlane": "INVALID",
            "Isotropic": "False",
            "ModalityProbabilities": "invalid_volume",
            "Bvalue": "-12345",
            "SeriesDescription": "*series_description_placeholder*",
            "Contrast": "None",
            "PixelSpacing_0": "U",
            "PixelSpacing_1": "N",
            "StudyInstanceUID": "*study_instance_UID_placeholder*",
            "SeriesInstanceUID": "*series_instance_UID_placeholder*",
            "SeriesNumber": "16",
            "ImageOrientationPatient": "UNKNOWN_ImageOrientationPatient",
            "PixelBandwidth": "UNKNOWN_PixelBandwidth",
```

and a valid ModalityProbabilities example:

```
        "6_0": {
            "VolumeModality": "t1w",
            "SeriesModality": "t1w",
            "AcqPlane": "ax",
            "Isotropic": "False",
            "ModalityProbabilities": {
                "GUESS_ONNX": "t1w",
                "GUESS_ONNX_t1w": "1.0",
                "GUESS_ONNX_gret2star": "0.0",
                "GUESS_ONNX_t2w": "0.0",
                "GUESS_ONNX_flair": "0.0",
                "GUESS_ONNX_b0": "0.0",
                "GUESS_ONNX_tracew": "0.0",
                "GUESS_ONNX_adc": "0.0",
                "GUESS_ONNX_fa": "0.0",
                "GUESS_ONNX_eadc": "0.0",
                "GUESS_ONNX_dwig": "0.0"
            },

```

A potential change we can look into is providing a more descriptive message for the `ModalityProbabilities` key.