### PR TITLE
Fix Infer Contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -549,3 +549,6 @@ dmypy.json
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
 **/__pycache__/**
+
+# MacOS generated files
+.DS_STORE

--- a/src/dcm_classifier/image_type_inference.py
+++ b/src/dcm_classifier/image_type_inference.py
@@ -223,7 +223,10 @@ class ImageTypeClassifierBase:
             return False
 
         # check if the volume has contrast
-        if "none" not in feature_dict[field].lower():
+        if (
+            "none" not in feature_dict[field].lower()
+            and feature_dict[field] != "-12345"
+        ):
             return True
         return False
 

--- a/tests/testing_data/anonymized_testing_data/contrast_data/without_contrast/no_contrastbolusagent_tag.dcm
+++ b/tests/testing_data/anonymized_testing_data/contrast_data/without_contrast/no_contrastbolusagent_tag.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d710631c61e7953e600b37d02ba3009ebe5b28f51b866cb7c29cca8e23a1468
+size 132604

--- a/tests/testing_data/integration_testing/classify_study_data/output.json
+++ b/tests/testing_data/integration_testing/classify_study_data/output.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c0e3d723c3bd7976e68491d0674bdefffde8a378bb0cf49fbea01bf63bb22e89
-size 33747
+oid sha256:99fa8d35856d8674bb0eb9285c2827177aef458bcf0be0e3213dd78abe3be882
+size 32980

--- a/tests/unit_testing/test_dicom_series.py
+++ b/tests/unit_testing/test_dicom_series.py
@@ -205,7 +205,9 @@ def test_dcm_series_no_contrast(no_contrast_file_path):
     study.run_inference()
 
     for series_number, series in study.series_dictionary.items():
-        assert series.get_has_contrast() is False
+        assert (
+            series.get_has_contrast() is False
+        ), f"File {series.get_volume_list()[0].get_one_volume_dcm_filenames()[0].name} came back with contrast"
 
 
 def test_dcm_series_has_contrast(contrast_file_path):


### PR DESCRIPTION
# Overview
`infer_contrast()` worked (and validated by a test) when ContrastBolusAgent tag existed and had the value of "NONE".

However, if the tag never existed in the source it's value would be set to -12345 during sanitation. This would cause all series without the tag present to be set as having contrast.

Add a check for the default value and a test to validate functionality. The test file is a copy of the existing test file with the ContrastBolusAgent tag removed and UIDs changed.

# Implementation
Add an additional check to see if the value of ContrastBolusAgent is the default value "-12345"

# Testing
Created a new test file with the tag removed.  This will be checked during `test_dcm_series_no_contrast()`

# Problems Faced
N/A

# Notes
N/A
