### PR TITLE
BUG: fix infer_contrast for missing ContrastBolusAgent tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -549,3 +549,6 @@ dmypy.json
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
 **/__pycache__/**
+
+# MacOS generated files
+.DS_STORE

--- a/src/dcm_classifier/image_type_inference.py
+++ b/src/dcm_classifier/image_type_inference.py
@@ -223,7 +223,10 @@ class ImageTypeClassifierBase:
             return False
 
         # check if the volume has contrast
-        if "none" not in feature_dict[field].lower():
+        if (
+            "none" not in feature_dict[field].lower()
+            and feature_dict[field] != "-12345"
+        ):
             return True
         return False
 

--- a/src/dcm_classifier/image_type_inference.py
+++ b/src/dcm_classifier/image_type_inference.py
@@ -223,10 +223,7 @@ class ImageTypeClassifierBase:
             return False
 
         # check if the volume has contrast
-        if (
-            "none" not in feature_dict[field].lower()
-            and feature_dict[field] != "-12345"
-        ):
+        if "none" not in feature_dict[field].lower():
             return True
         return False
 

--- a/src/dcm_classifier/utility_functions.py
+++ b/src/dcm_classifier/utility_functions.py
@@ -766,7 +766,15 @@ def get_coded_dictionary_elements(
                 else:
                     dataset_dictionary[feature] = 0
         elif name == "ContrastBolusAgent":
-            no_contrast_list = ["none", "no", "no contrast", "no_contrast", "n", ""]
+            no_contrast_list = [
+                "none",
+                "no",
+                "no contrast",
+                "no_contrast",
+                "n",
+                "",
+                "-12345",
+            ]
             if str(value).lower() in no_contrast_list:
                 dataset_dictionary["ContrastBolusAgent"] = "None"
             else:

--- a/tests/testing_data/anonymized_testing_data/contrast_data/without_contrast/no_contrastbolusagent_tag.dcm
+++ b/tests/testing_data/anonymized_testing_data/contrast_data/without_contrast/no_contrastbolusagent_tag.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d710631c61e7953e600b37d02ba3009ebe5b28f51b866cb7c29cca8e23a1468
+size 132604

--- a/tests/testing_data/integration_testing/classify_study_data/output.json
+++ b/tests/testing_data/integration_testing/classify_study_data/output.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99fa8d35856d8674bb0eb9285c2827177aef458bcf0be0e3213dd78abe3be882
-size 32980
+oid sha256:eac37171712b3b71e90a9f200e24f84f735ea9d50b48691a897d14b030c32e38
+size 32941

--- a/tests/testing_data/integration_testing/classify_study_data/output.json
+++ b/tests/testing_data/integration_testing/classify_study_data/output.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c0e3d723c3bd7976e68491d0674bdefffde8a378bb0cf49fbea01bf63bb22e89
-size 33747
+oid sha256:99fa8d35856d8674bb0eb9285c2827177aef458bcf0be0e3213dd78abe3be882
+size 32980

--- a/tests/unit_testing/test_dicom_series.py
+++ b/tests/unit_testing/test_dicom_series.py
@@ -205,7 +205,9 @@ def test_dcm_series_no_contrast(no_contrast_file_path):
     study.run_inference()
 
     for series_number, series in study.series_dictionary.items():
-        assert series.get_has_contrast() is False
+        assert (
+            series.get_has_contrast() is False
+        ), f"File {series.get_volume_list()[0].get_one_volume_dcm_filenames()[0].name} came back with contrast"
 
 
 def test_dcm_series_has_contrast(contrast_file_path):


### PR DESCRIPTION
## Summary
- Fixes a bug where DICOM volumes missing the `ContrastBolusAgent` tag were incorrectly classified as having contrast
- Moves the fix to the correct layer: adds `"-12345"` (the sentinel for missing optional fields) to the `no_contrast_list` in `get_coded_dictionary_elements()` (`utility_functions.py`) so the value is normalized to `"None"` at the sanitization layer rather than patched downstream in `infer_contrast()`
- Reverts the downstream band-aid in `infer_contrast()` since it is no longer needed
- Regenerated the integration test baseline `output.json` to match the corrected output

## Test plan
- [x] `test_dcm_series_no_contrast` — verifies series with no contrast tag returns `False`
- [x] `test_dcm_series_has_contrast` — verifies series with a real contrast agent still returns `True`
- [x] `test_classify_study_json` — integration test comparing full JSON output against regenerated baseline
- [x] Full suite: `python3 -Werror::FutureWarning -m pytest tests` — 81 passed, 3 skipped

## Notes
Builds on the original work from PR #84 by @ChanceSauley, including the new `no_contrastbolusagent_tag.dcm` test file and improved assertion message in `test_dcm_series_no_contrast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)