### PR TITLE
Add MR SOP class filter

### DIFF
--- a/src/dcm_classifier/study_processing.py
+++ b/src/dcm_classifier/study_processing.py
@@ -26,6 +26,7 @@ from .image_type_inference import ImageTypeClassifierBase
 from .utility_functions import (
     check_two_images_have_same_physical_space,
     parse_acquisition_datetime,
+    is_mr_sop_class,
 )
 
 
@@ -118,6 +119,7 @@ class ProcessOneDicomStudyToVolumesMappingBase:
         study_directory: str | Path,
         search_series: dict[str, int] | None = None,
         inferer: ImageTypeClassifierBase | None = None,
+        mr_sop_class_only: bool = False,
         raise_error_on_failure: bool = False,
     ) -> None:
         """
@@ -128,6 +130,7 @@ class ProcessOneDicomStudyToVolumesMappingBase:
 
         :param study_directory: str | Path: The path to the DICOM study directory.
         :param search_series: Optional[Dict[str, int]]: A dictionary of series to search within the study.
+        :param mr_sop_class_only: bool: Optional. Only process series with an MR SOP Class UID.
         :param inferer: Optional[ImageTypeClassifierBase]: An image type classifier for inference.
 
         """
@@ -141,7 +144,7 @@ class ProcessOneDicomStudyToVolumesMappingBase:
         self.raise_error_on_failure: bool = raise_error_on_failure
         self.search_series: dict[str, int] | None = search_series
         self.series_dictionary: dict[int, DicomSingleSeries] = (
-            self.__identify_single_volumes(self.study_directory)
+            self.__identify_single_volumes(self.study_directory, mr_sop_class_only)
         )
         self.inferer: ImageTypeClassifierBase | None = inferer
 
@@ -296,6 +299,7 @@ class ProcessOneDicomStudyToVolumesMappingBase:
     def __identify_single_volumes(
         self,
         study_directory: Path,
+        mr_sop_class_only: bool = False,
     ) -> dict[int, DicomSingleSeries]:
         """
         Identify and map single volumes within the DICOM study directory.
@@ -306,6 +310,9 @@ class ProcessOneDicomStudyToVolumesMappingBase:
 
         :param study_directory: The path to the DICOM study directory.
         :type study_directory: Path
+
+        :param mr_sop_class_only: Optional. Only retrieve series with a MR SOP Class UID.
+        :type mr_sop_class_only: bool
 
         :return: A dictionary mapping series numbers to DicomSingleSeries objects.
         :rtype: dict[int, DicomSingleSeries]
@@ -346,9 +353,6 @@ class ProcessOneDicomStudyToVolumesMappingBase:
             print(
                 f"The directory: {study_directory} contains {len(seriesUID)} DICOM series"
             )
-        # print(f"Contains the following {len(seriesUID)} DICOM Series: ")
-        # for uid in seriesUID:
-        #     print(uid)
 
         volumes_dictionary: dict[int, DicomSingleSeries] = dict()
 
@@ -358,6 +362,15 @@ class ProcessOneDicomStudyToVolumesMappingBase:
             subseries_filenames: list[str] = namesGenerator.GetFileNames(
                 seriesIdentifier
             )
+
+            if (
+                mr_sop_class_only
+                and subseries_filenames
+                and not is_mr_sop_class(
+                    pydicom.dcmread(subseries_filenames[0], stop_before_pixels=True)
+                )
+            ):
+                continue
 
             # Use our pydicom-based splitter to handle multi-volume logic
             sub_volumes = self._identify_and_split_sub_volumes_pydicom(

--- a/src/dcm_classifier/utility_functions.py
+++ b/src/dcm_classifier/utility_functions.py
@@ -21,6 +21,12 @@ from typing import Any
 import collections
 
 import pydicom
+from pydicom.uid import (
+    MRImageStorage,
+    EnhancedMRImageStorage,
+    EnhancedMRColorImageStorage,
+    LegacyConvertedEnhancedMRImageStorage,
+)
 from copy import deepcopy
 import itk
 import warnings
@@ -129,6 +135,15 @@ def is_integer(s: Any) -> bool:
         return True
     except Exception:
         return False
+
+
+def is_mr_sop_class(dicom_header_info: Dataset):
+    return dicom_header_info.SOPClassUID in [
+        MRImageStorage,
+        EnhancedMRImageStorage,
+        EnhancedMRColorImageStorage,
+        LegacyConvertedEnhancedMRImageStorage,
+    ]
 
 
 def get_bvalue(dicom_header_info: Dataset, round_to_nearst_10: bool = True) -> float:

--- a/tests/unit_testing/test_utility_functions.py
+++ b/tests/unit_testing/test_utility_functions.py
@@ -16,6 +16,7 @@ from dcm_classifier.utility_functions import (
     get_coded_dictionary_elements,
     get_bvalue,
     validate_numerical_dataset_element,
+    is_mr_sop_class,
 )
 from dcm_classifier.dicom_config import required_DICOM_fields, optional_DICOM_fields
 from pathlib import Path
@@ -351,6 +352,16 @@ def test_is_integer():
     assert is_integer("1") is True
     assert is_integer("test") is False
     assert is_integer("1.0") is False
+
+
+def test_is_mr_sop_class(contrast_file_path):
+    dcm_header_info = pydicom.dcmread(
+        list(contrast_file_path.rglob("*.dcm"))[0], stop_before_pixels=True
+    )
+    assert is_mr_sop_class(dcm_header_info)
+
+    dcm_header_info.SOPClassUID = pydicom.uid.CTImageStorage
+    assert not is_mr_sop_class(dcm_header_info)
 
 
 def test_conv_arr_to_index_val():


### PR DESCRIPTION
# Overview
Add a boolean to optionally only process series with a valid MR SOP class.

This solves an uncommon but widespread issue where someone will scan a document to attach to a patient's study in their PACS. However, it is incorrectly marked as an MR modality and can be missing the series number DICOM tag. When processing that study directory, an error would be thrown on initialization of `ProcessOneDicomStudyToVolumesMappingBase`

# Implementation
Added a optional argument to specify that only MR SOP classes are considered.

# Testing
Previous Issue that is now fixed:

```
File /Users/csauley/dcm_classifier/study_processing.py", line 370, in __identify_single_volumes
    sn = int(volume_obj.get_dicom_field_by_name("SeriesNumber"))
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'UNKNOWN_SeriesNumber'
```

# Problems Faced
<!-- _Did you run into any problems, if so how did you resolve them?_ -->

# Notes
This could be implemented by default. However, I defaulted to `False` to preserve current functionality one to one for the initial review.
