### PR TITLE
Sort to prevent difference with OS used during test

### DIFF
--- a/src/dcm_classifier/study_processing.py
+++ b/src/dcm_classifier/study_processing.py
@@ -437,6 +437,8 @@ class ProcessOneDicomStudyToVolumesMappingBase:
         """
         if not subseries_filenames:
             return []
+        # Sort to prevent differences between operating systems
+        subseries_filenames = sorted(subseries_filenames)
 
         INVALID_NUMERICAL_VALUE = -12345
         file_info_dict = defaultdict(list)

--- a/tests/testing_data/integration_testing/classify_study_data/output.json
+++ b/tests/testing_data/integration_testing/classify_study_data/output.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c0e3d723c3bd7976e68491d0674bdefffde8a378bb0cf49fbea01bf63bb22e89
-size 33747
+oid sha256:e3986ad1523e68f19738351d734cd147a1eb56f979e077ec7bd8822267d096e7
+size 33744


### PR DESCRIPTION
# Overview
Previously, the integration test would fail on Ubuntu 24.04 systems but pass on MacOS.
This fixes it so that the test passes regardless of OS used.

# Implementation
Sorted the `subseries_filenames` and regenerated the `output.json` for reference

# Testing
Tested it on MacOS and Ubuntu 24.04

# Notes
### On Ubuntu 24.04 VM:
<img width="758" height="87" alt="image" src="https://github.com/user-attachments/assets/4b6c97a9-116b-4d87-85d8-61dd7bb270c8" />

### On MacOS:
<img width="573" height="62" alt="image" src="https://github.com/user-attachments/assets/fc05eb47-2501-47fa-936a-a4714a740041" />

### Difference between in reference file during test:
<img width="758" height="307" alt="image" src="https://github.com/user-attachments/assets/52d6af89-34bf-40c2-83ff-4022e95ec35b" />

